### PR TITLE
create `.prettierrc` (sample)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "trailingComma": "all",
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "jsxSingleQuote": true,
+  "jsxBracketSameLine": false,
+  "printWidth": 80
+}


### PR DESCRIPTION
# referenced issue

- #6

# changes

- prettierrc を作った
  - 完全に俺の肌感で決めているので適宜修正入れてから使ってね

# tips

多分エディターの設定で自動フォーマットを使ってないのが原因で気づかなかったのかなと考えた.  
VSCode では以下の設定を入れれば勝手にフォーマットしてくれるので使ってね(青線引かれている項目)
![スクリーンショット 2021-11-20 123722](https://user-images.githubusercontent.com/40014236/142713225-cab01f05-17c1-4e53-ae48-b3ed7a9e8712.png)


