### PR TITLE
change import path as absolute from projectRoot

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,7 +2,7 @@ import { Flex, Text } from '@chakra-ui/layout';
 
 const Footer = () => {
   return (
-    <Flex as="footer" p={6} bg="gray.100" color="black" justifyContent="center">
+    <Flex as='footer' p={6} bg='gray.100' color='black' justifyContent='center'>
       <Text>mopeneko</Text>
     </Flex>
   );

--- a/pages/[id].tsx
+++ b/pages/[id].tsx
@@ -1,12 +1,12 @@
 import { GetStaticProps } from 'next';
 import { NextSeo } from 'next-seo';
 import { Container, Heading, Text, Box } from '@chakra-ui/layout';
-import dayjs from 'dayjs';
-import Footer from '../components/Footer';
-import Header from '../components/Header';
-import { client } from '../libs/client';
 import { Article } from 'mopeneko_blog';
-import HTMLRenderer from '../components/HTMLRenderer';
+import dayjs from 'dayjs';
+import Footer from 'components/Footer';
+import Header from 'components/Header';
+import { client } from 'libs/client';
+import HTMLRenderer from 'components/HTMLRenderer';
 
 type Props = {
   article: Article;
@@ -42,7 +42,7 @@ const ArticleDetail: React.FC<Props> = ({ article }) => {
       <NextSeo title={`${article.title} - もペブログ`} />
 
       <Header />
-      <Container maxW="container.md" pt={4}>
+      <Container maxW='container.md' pt={4}>
         <article>
           <Heading>{article.title}</Heading>
           <Text>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,11 @@
 import { GetStaticProps } from 'next';
 import { Container } from '@chakra-ui/react';
 import { NextSeo } from 'next-seo';
-import { client } from '../libs/client';
-import Header from '../components/Header';
-import Footer from '../components/Footer';
-import ArticleList from '../components/ArticleList';
 import type { Article } from 'mopeneko_blog';
+import { client } from 'libs/client';
+import Header from 'components/Header';
+import Footer from 'components/Footer';
+import ArticleList from 'components/ArticleList';
 
 type Props = {
   articles: Article[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true
+    "incremental": true,
+    "baseUrl": "."
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
# referenced issue

- close #9

# changes

- tsconfig.json に `baseUrl: "."` の設定を追加
  - これをするとプロジェクトルートからの絶対パス参照が可能になる
- import 文の相対パスを滅ぼした
- ついでにlint fixも実施

# tips

- 動作確認してね
- このPRで linter の警告がなくなりました :tada:
![スクリーンショット 2021-11-20 132422](https://user-images.githubusercontent.com/40014236/142714333-4c345f1e-5b66-440c-8ed5-523bed40b7ba.png)

